### PR TITLE
Base64 output streaming

### DIFF
--- a/background.js
+++ b/background.js
@@ -653,10 +653,10 @@ async function base64_listener(details) {
                 let byteCount = imageDataURI.length*3/4;
 
                 if(byteCount >= MIN_IMAGE_BYTES) {
-                    let img = await loadImagePromise(imageDataURI);
                     console.log('base64 image loaded: '+imageId);
                     try
                     {
+                        let img = await loadImagePromise(imageDataURI);
                         if(img.width>=MIN_IMAGE_SIZE && img.height>=MIN_IMAGE_SIZE){ //there's a lot of 1x1 pictures in the world that don't need filtering!
                             console.log('base64 predict '+imageId+' size '+img.width+'x'+img.height+', materialization occured with '+byteCount+' bytes');
                             let sqrxrScore = predict(img);


### PR DESCRIPTION
This is a partial implementation of streaming for the base64 listener. It doesn't process as the bytes come in - it only starts after they are all there - but still gives a boost because it outputs in a streaming fashion upon prediction completion. Plus, I think it actually cleaned up the code a bit due to the wrapping of image onload as a promise.