### PR TITLE
Catching video loading event-not-called issue with a timeout, cleanin…

### DIFF
--- a/background_video.js
+++ b/background_video.js
@@ -706,6 +706,10 @@ async function vidYtMp4Listener(details, mimeType, parsedUrl) {
     let cpn = parsedUrl.searchParams.get('cpn');
     let videoChainId = 'yt-mp4-'+cpn+'-'+details.requestId;
     let rangeRaw = parsedUrl.searchParams.get('range');
+    if(rangeRaw === undefined || rangeRaw === null) {
+        console.warn(`YTFMP4: For request ${details.requestId} ${cpn}, failed to get the range, aborting. URL: ${details.url}`);
+        return details;
+    }
     console.info('YTVMP4: Starting request '+details.requestId+' '+cpn+', '+rangeRaw);
     let splitIndex = rangeRaw.indexOf('-'); //e.g. range=0-3200
     let rangeStart = parseInt(rangeRaw.substr(0, splitIndex));


### PR DESCRIPTION
…g up range detection failure

Fixes #127 - The expected events were never called, so created a catch-all timeout-based handler.

Note, this passes the video through but it still doesn't appears to scan properly.