### PR TITLE
"In proc" Background.js Backend Option for Hidden Tab Challenges

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,15 @@
           "encoders_data.js",
           "encoders.js",
           "background_gif.js",
+
+          "libs/tfjs_3.11.0.js",
+          "libs/tf-backend-wasm.min.js",
+          "libs/mux_5.1.2.js",
+          "silent_data/index.js",
+          "silent_mode.js",
+          "processor.js",
+          "processor_backgroundstartup.js",
+
           "background.js",
           "background_video.js",
           "whitelist.js"

--- a/options.html
+++ b/options.html
@@ -51,6 +51,7 @@
     <br />
     <h4>Which Tensorflow.js processing backend should be used? (Advanced option)</h4>
     <input type="radio" name="backend_selection" id="backend_selection_webgl" value="webgl" checked><label for="backend_selection_webgl">WebGL only</label> <br />
+    <input type="radio" name="backend_selection" id="backend_selection_inprocwebgl" value="inprocwebgl"><label for="backend_selection_inprocwebgl">Background.js WebGL, fallback to WebGL (a bit slower, tries to avoid hidden tab, use for compatibility)</label> <br />
     <input type="radio" name="backend_selection" id="backend_selection_wasm" value="wasm"><label for="backend_selection_wasm">WASM only</label> <br />
     <input type="radio" name="backend_selection" id="backend_selection_webgl_wasm" value="webgl_wasm"><label for="backend_selection_webgl_wasm">WebGL (primary) + WASM (secondary)</label> <br />
     <input type="radio" name="backend_selection" id="backend_selection_wasm_webgl" value="wasm_webgl"><label for="backend_selection_wasm_webgl">WASM (primary) + WebGL (secondary)</label> <br />

--- a/options.js
+++ b/options.js
@@ -92,7 +92,7 @@ function optRestoreOptions() {
     function setCurrentBackendSelectionSwitchChoice(rawResult) {
         let result = rawResult.backend_selection;
         console.log('OPTION: Setting backend to ' + result);
-        let coercedResult = result || 'inprocwebgl';
+        let coercedResult = result || 'webgl';
         document.getElementById('backend_selection_' + coercedResult).checked = true;
         browser.runtime.sendMessage({ type: 'setBackendSelection', value: coercedResult });
     }

--- a/options.js
+++ b/options.js
@@ -92,7 +92,7 @@ function optRestoreOptions() {
     function setCurrentBackendSelectionSwitchChoice(rawResult) {
         let result = rawResult.backend_selection;
         console.log('OPTION: Setting backend to ' + result);
-        let coercedResult = result || 'webgl';
+        let coercedResult = result || 'inprocwebgl';
         document.getElementById('backend_selection_' + coercedResult).checked = true;
         browser.runtime.sendMessage({ type: 'setBackendSelection', value: coercedResult });
     }

--- a/processor.html
+++ b/processor.html
@@ -7,6 +7,7 @@
         <script src="silent_data/index.js"></script>
         <script src="silent_mode.js"></script>
         <script src="processor.js"></script>
+        <script src="processor_tabstartup.js"></script>
     </head>
     <body>
         Wingman Jr. creates a test page for processing that is usually hidden.

--- a/processor.js
+++ b/processor.js
@@ -12,10 +12,8 @@ function procOnModelLoadProgress(percentage) {
 let PROC_isInReviewMode = false;
 let PROC_wingman;
 let PROC_loadedBackend;
-const procWingmanStartup = async () => {
+const procWingmanStartup = async (backendRequested) => {
     WJR_DEBUG && console.log('LIFECYCLE: Launching TF.js!');
-    let params = (new URL(document.location)).searchParams;
-    let backendRequested = params.get('backend');
     WJR_DEBUG && console.log('LIFECYCLE: Backend requested '+backendRequested);
     if(backendRequested != 'default') {
         tf.setBackend(backendRequested || 'wasm');
@@ -854,16 +852,3 @@ async function procOnPortMessage(m) {
 }
 
 let PROC_port = null;
-let PROC_processorId = (new URL(document.location)).searchParams.get('id');
-procWingmanStartup()
-.then(async ()=>
-{
-    PROC_port = browser.runtime.connect(browser.runtime.id, {name:PROC_processorId});
-    PROC_port.onMessage.addListener(procOnPortMessage);
-    PROC_port.postMessage({
-        type: 'registration',
-        tabId: (await browser.tabs.getCurrent()).id,
-        processorId: PROC_processorId,
-        backend: PROC_loadedBackend
-    });
-});

--- a/processor_backgroundstartup.js
+++ b/processor_backgroundstartup.js
@@ -1,0 +1,90 @@
+let PROC_processorId = 'inprocwebgl';
+function bkTryStartupBackgroundJsProcessor() {
+    // In Firefox 83, background.js Tensorflow.js inference fell back to CPU for
+    // many users, essentially making the browsing experience unusuable. The addon
+    // was rewritten in a client/server architecture to allow for a hidden tab to
+    // use a "normal" environment to spawn the WebGL context.
+    // However, the hidden tab has been the #2/#3 reason why users are leaving
+    // according to the addon's exit survey.
+    // This code is an attempt to create an "in proc" client as an attempt to
+    // dodge the need for a hidden tab when possible so users don't get angry.
+    //
+    // First, perform similar detection to what Tensorflow.js will do
+    // and only proceed if detection succeeds. Otherwise, Tensorflow.js
+    // will fail and the hidden tab approach must be used instead
+    console.log('INPROC: Performing Tensorflow.js WebGL check for background.js...');
+    let inferenceCanvas = document.createElement('canvas');
+    let inferenceCtx = inferenceCanvas.getContext('webgl2',
+    {
+        alpha: false,
+        antialias: false,
+        premultipliedAlpha: false,
+        preserveDrawingBuffer: false,
+        depth: false,
+        stencil: false,
+        failIfMajorPerformanceCaveat: true
+    });
+    if(!inferenceCtx) {
+        console.log('INPROC: Tensorflow.js WebGL check for background.js failed, falling back to hidden tab.');
+        return null;
+    }
+    
+    let inferenceCtxType = `${inferenceCtx}`;
+    console.log(`INPROC: Tensorflow.js WebGL check for background.js succeeded, continuing in-process! (${inferenceCtxType})`);
+    delete inferenceCtx;
+    delete inferenceCanvas;
+    //Initialize and fake out a port pair for processor and background
+    procWingmanStartup('webgl')
+    .then(async ()=>
+    {
+        let backgroundPort = null;
+        let listenersBackgroundSide = [];
+        let listenersProcessorSide = [];
+        PROC_port = {
+            name: PROC_processorId,
+            postMessage: function(m) {
+                WJR_DEBUG && console.debug('INPROC: postMessage (proc side) '+m.type);
+                listenersBackgroundSide.forEach(lb => {
+                    try { lb(m); } catch { }
+                })
+            },
+            onMessage: {
+                addListener: function(listenerFunction) {
+                    WJR_DEBUG && console.log('INPROC: Adding new listener to fake port (proc side)');
+                    listenersProcessorSide.push(listenerFunction);
+                }
+            },
+            destroy: function() {
+                listenersProcessorSide.length = 0;
+            }
+        };
+        
+        backgroundPort = {
+            name: PROC_processorId,
+            postMessage: function(m) {
+                WJR_DEBUG && console.debug('INPROC: postMessage (background side)'+m.type);
+                listenersProcessorSide.forEach(lp => {
+                    try { lp(m); } catch { }
+                });
+            },
+            onMessage: {
+                addListener: function(listenerFunction) {
+                    WJR_DEBUG && console.log('INPROC: Adding new listener to fake port (background side)');
+                    listenersBackgroundSide.push(listenerFunction);
+                }
+            },
+            destroy: function() {
+                listenersBackgroundSide.length = 0;
+            }
+        };
+        PROC_port.onMessage.addListener(procOnPortMessage);
+        bkOnClientConnected(backgroundPort);
+        PROC_port.postMessage({
+            type: 'registration',
+            tabId: 'fake',
+            processorId: PROC_processorId,
+            backend: PROC_loadedBackend
+        });
+    });
+    return inferenceCtxType;
+}

--- a/processor_tabstartup.js
+++ b/processor_tabstartup.js
@@ -1,0 +1,13 @@
+let PROC_processorId = (new URL(document.location)).searchParams.get('id');
+procWingmanStartup((new URL(document.location)).searchParams.get('backend'))
+.then(async ()=>
+{
+    PROC_port = browser.runtime.connect(browser.runtime.id, {name:PROC_processorId});
+    PROC_port.onMessage.addListener(procOnPortMessage);
+    PROC_port.postMessage({
+        type: 'registration',
+        tabId: (await browser.tabs.getCurrent()).id,
+        processorId: PROC_processorId,
+        backend: PROC_loadedBackend
+    });
+});


### PR DESCRIPTION
This PR brings back the option of running Tensorflow.js from within the "main" background.js context.

This is how the addon originally worked, but due to certain interactions between Firefox 83 and Tensorflow.js, many users saw Tensorflow.js no longer work in an accelerated way - causing the browser to almost halt. This was a serious issue, causing most of the original user base to leave and required completely rewriting Wingman Jr. to work in a client server fashion, delegating out the Tensorflow.js processing work to a hidden tab so that Tensorflow.js could run in a "real" web context. See https://wingman-jr.blogspot.com/2020/12/firefox-83-fix-in-progress.html

BUT...

The hidden tab is a big pain for folks. While I have a note about it in the main addon page, it still causes confusion. Additionally, if Tensorflow.js has a crash or calculation instability, the hidden tab ends up respawning, causing further frustration. (Also, reported this to WECG as a reason to reconsider the current service worker proposal: https://github.com/w3c/webextensions/issues/73#issuecomment-1107952600)  Many users leave because of this single issue - it's probably the number 2 or 3 reason for leaving. Here's a spicy quote from my exit survey for example:  "the f***ing hidden tabs notification kept popping up every 10 seconds, why tf is the tab restarting every 10 seconds". So it's time for  a change.

The approach here to start with is to add a new backend. The backend probes for hardware acceleration in the same way Tensorflow.js does, and if successful, just runs in the background. If the probe fails, it starts up a hidden tab like usual. Note that I see it running at about 2/3 the speed of the hidden tab, so it may not be suitable as the default. However, future work might be to make this smarter - add some prompt if lots of respawning is happening to choose this option etc.

Try it out and let me know what you think!