### PR TITLE
Site-Oriented: Refactor threshold communication to go per-request

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,7 +36,6 @@ function bkOnClientConnected(port) {
     BK_connectedClients[registration.processorId] = registration;
     WJR_DEBUG && console.log(`LIFECYCLE: There are now ${Object.keys(BK_connectedClients).length} processors`);
     port.onMessage.addListener(bkOnProcessorMessage);
-    bkNotifyThreshold();
     bkBroadcastProcessorSettings();
     if (!BK_isInitialized) {
         BK_isInitialized = true;
@@ -295,15 +294,7 @@ function bkSetZone(newZone)
     if(didZoneChange) {
         WJR_DEBUG && console.log("Zone precision is: "+BK_zonePrecision);
         bkClearPredictionBuffer();
-        bkNotifyThreshold();
     }
-}
-
-function bkNotifyThreshold() {
-    bkBroadcastMessageToProcessors({
-        type: 'thresholdChange',
-        threshold: BK_zoneThreshold
-    });
 }
 
 ////////////////////// ZONE END //////////////////////////
@@ -387,7 +378,8 @@ async function bkCrashDetectionWatchdog() {
             type: 'start',
             requestId: pseudoRequestId,
             mimeType: 'image/jpeg',
-            url: pseudoRequestId
+            url: pseudoRequestId,
+            threshold: BK_zoneThreshold
         });
         processor.postMessage({
             type: 'ondata',
@@ -484,7 +476,8 @@ async function bkImageListenerNormal(details, mimeType) {
         type: 'start',
         requestId: details.requestId,
         mimeType: mimeType,
-        url: details.url
+        url: details.url,
+        threshold: BK_zoneThreshold
     });
     statusStartImageCheck(details.requestId);
 
@@ -632,7 +625,8 @@ async function bkBase64ContentListener(details) {
     let processor = bkGetNextProcessor().port;
     processor.postMessage({
         type: 'b64_start',
-        requestId: details.requestId
+        requestId: details.requestId,
+        threshold: BK_zoneThreshold
     });
 
     filter.ondata = evt => {

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,6 @@
           "status.js",
           "encoders_data.js",
           "encoders.js",
-          "background_gif.js",
 
           "libs/tfjs_3.11.0.js",
           "libs/tf-backend-wasm.min.js",
@@ -43,6 +42,7 @@
 
           "background.js",
           "background_video.js",
+          "background_gif.js",
           "whitelist.js"
         ]
     },

--- a/processor.js
+++ b/processor.js
@@ -777,7 +777,8 @@ async function procOnPortMessage(m) {
                 url: m.url,
                 mimeType: m.mimeType,
                 startTime: performance.now(),
-                buffers: m.buffers
+                buffers: m.buffers,
+                threshold: m.threshold
             };
             let gifScanResult = await procPerformFiltering(gifRequest);
             let gifResponse = {

--- a/processor.js
+++ b/processor.js
@@ -263,12 +263,6 @@ async function procCommonCreateSvg(img, sqrxrScore, dataURL)
     }
 }
 
-let PROC_checkThreshold = ROC_neutralRoc;
-
-function procSetThreshold(threshold) {
-    PROC_checkThreshold = threshold;
-}
-
 function procScoreToStr(sqrxrScore) {
     return sqrxrScore[0][0].toFixed(5) + ' ('+
         sqrxrScore[1][0].toFixed(2)+', '+
@@ -277,8 +271,8 @@ function procScoreToStr(sqrxrScore) {
         sqrxrScore[1][3].toFixed(2)+')';
 }
 
-function procIsSafe(sqrxrScore) {
-    return sqrxrScore[0][0] < PROC_checkThreshold;
+function procIsSafe(sqrxrScore, threshold) {
+    return sqrxrScore[0][0] < threshold;
 }
 
 const procLoadImagePromise = url => new Promise( (resolve, reject) => {
@@ -314,7 +308,7 @@ async function procPerformFiltering(entry) {
                 WJR_DEBUG && console.debug('ML: predict '+entry.requestId+' size '+img.width+'x'+img.height+', materialization occured with '+byteCount+' bytes');
                 let imgLoadTime = performance.now();
                 let sqrxrScore = await procPredict(img);
-                if(procIsSafe(sqrxrScore)) {
+                if(procIsSafe(sqrxrScore, entry.threshold)) {
                     WJR_DEBUG && console.log('ML: Passed: '+procScoreToStr(sqrxrScore)+' '+entry.requestId);
                     result.result = 'pass';
                     result.imageBytes = await blob.arrayBuffer();
@@ -423,7 +417,7 @@ async function procCompleteB64Filtering(b64Filter, outputPort) {
                     let sqrxrScore = await procPredict(img);
                     WJR_DEBUG && console.debug('ML: base64 score: '+procScoreToStr(sqrxrScore));
                     let replacement = null; //safe
-                    if(procIsSafe(sqrxrScore)) {
+                    if(procIsSafe(sqrxrScore, b64Filter.threshold)) {
                         outputPort.postMessage({
                             type:'stat',
                             result:'pass',
@@ -663,6 +657,7 @@ async function procGetVideoScanStatus(
     url,
     mimeType,
     buffers,
+    threshold,
     scanStart,
     scanStep,
     scanMaxSteps,
@@ -703,7 +698,7 @@ async function procGetVideoScanStatus(
             sqrxrScore = await procPredict(inferenceVideo);
             scanResults.scanCount++;
             let frameStatus;
-            if(procIsSafe(sqrxrScore))
+            if(procIsSafe(sqrxrScore, threshold))
             {
                 WJR_DEBUG && console.log('MLV: SCAN PASS video score @'+seekTime+': '+procScoreToStr(sqrxrScore)+' type '+requestType+', MIME '+mimeType+' for video group '+videoChainId);
                 await procCommonLogImg(inferenceVideo, 'MLV: SCAN PASS VID @'+seekTime+' '+procScoreToStr(sqrxrScore));
@@ -748,6 +743,7 @@ async function procOnPortMessage(m) {
                 requestId: m.requestId,
                 url: m.url,
                 mimeType: m.mimeType,
+                threshold: m.threshold,
                 startTime: performance.now(),
                 buffers: []
             };
@@ -795,6 +791,7 @@ async function procOnPortMessage(m) {
         case 'b64_start': {
             PROC_openB64Requests[m.requestId] = {
                 requestId: m.requestId,
+                threshold: m.threshold,
                 startTime: performance.now(),
                 fullStr: ''
             };
@@ -820,6 +817,7 @@ async function procOnPortMessage(m) {
                 m.url,
                 m.mimeType,
                 m.buffers,
+                m.threshold,
                 m.scanStart,
                 m.scanStep,
                 m.scanMaxSteps,
@@ -837,11 +835,6 @@ async function procOnPortMessage(m) {
                     console.error(`DATAV: Failed to post video result for ${m.requestId} because ${e}, unsure how to proceed.`);
                 }
             }
-        }
-        break;
-        case 'thresholdChange': {
-            WJR_DEBUG && console.log('PROC: Setting threshold '+m.threshold);
-            procSetThreshold(m.threshold);
         }
         break;
         default: {


### PR DESCRIPTION
Part of #211 . Do this so that individual requests carry all necessary information to processors to perform filtering, allowing individual requests to e.g. have different thresholds for different sites.