### PR TITLE
Fix undefined variable bug in mp4 probe

### DIFF
--- a/mp4.js
+++ b/mp4.js
@@ -395,6 +395,6 @@ function mp4IsLikelyProbe(u8Array) {
     if(u8Array.byteLength < 8) {
         return false;
     }
-    let ftypType = mp4ReadType(initBuffer, offset+4);
+    let ftypType = mp4ReadType(u8Array, 4);
     return ftypType == 'ftyp';
 }


### PR DESCRIPTION
Correct variable references in `mp4IsLikelyProbe` to be input instead of undefined variable.