### PR TITLE
Minor video threshold consistency fix

### DIFF
--- a/background_video.js
+++ b/background_video.js
@@ -438,7 +438,7 @@ async function vidDefaultListener(details, mimeType, parsedUrl, expectedContentL
     return details;
 }
 
-function vidCheckCreateDashGroup(url) {
+function vidCheckCreateDashGroup(url, threshold) {
     let dashGroup = VID_DASH_GROUPS[url];
     if(dashGroup === undefined) {
         dashGroup = {
@@ -447,10 +447,13 @@ function vidCheckCreateDashGroup(url) {
             actions: [],
             fmp4: null,
             webm: null,
+            threshold: threshold,
             scanCount: 0,
             blockCount: 0
         };
         VID_DASH_GROUPS[url] = dashGroup;
+    } else if (dashGroup.threshold === undefined && threshold !== undefined) {
+        dashGroup.threshold = threshold;
     }
     return dashGroup;
 }
@@ -495,6 +498,9 @@ async function vidDashMp4Listener(details, mimeType, parsedUrl, range, threshold
 
     let dashGroupPrecheck = VID_DASH_GROUPS[url];
     if (dashGroupPrecheck !== undefined) {
+        if (dashGroupPrecheck.threshold === undefined) {
+            dashGroupPrecheck.threshold = threshold;
+        }
         if(dashGroupPrecheck.status == 'pass') {
             console.warn(`DASHVMP4: Already passed for request id ${details.requestId} range ${range.start}-${range.end} with original request ${dashGroupPrecheck.startRequestId} for URL ${url}`);
             dashGroupPrecheck.actions.push({ requestId: details.requestId, range: range, action: 'precheck-pass'});
@@ -548,7 +554,7 @@ async function vidDashMp4Listener(details, mimeType, parsedUrl, range, threshold
             
             if(range.start == 0) {
                 WJR_DEBUG && console.debug(`DASHVMP4: New FMP4 for ${details.requestId} at${url}`);
-                let dashGroup = vidCheckCreateDashGroup(url);
+                let dashGroup = vidCheckCreateDashGroup(url, threshold);
                 dashGroup.startRequestId = details.requestId;
 
                 let fullBuffer = vidConcatBuffersToUint8Array(buffers);
@@ -647,6 +653,7 @@ async function vidDashMp4Listener(details, mimeType, parsedUrl, range, threshold
                 statusCompleteVideoCheck(details.requestId, status);
                 return;
             }
+            let scanThreshold = dashGroup.threshold ?? threshold;
             let scanResults = await vidPerformVideoScan(
                 processor,
                 videoChainId,
@@ -655,7 +662,7 @@ async function vidDashMp4Listener(details, mimeType, parsedUrl, range, threshold
                 details.url,
                 details.type,
                 scanBuffers,
-                threshold,
+                scanThreshold,
                 scanStart,
                 scanStep,
                 effectiveScanMaxSteps,
@@ -709,5 +716,4 @@ async function vidDashMp4Listener(details, mimeType, parsedUrl, range, threshold
     }
     return details;
 }
-
 


### PR DESCRIPTION
## Developer Notes
Originally I thought I still had the thresholds being set "globally" for the processors so I thought there was more to do to refactor but it turns out I was already pushing the thresholds to the processors, which is in line with the future "per-site" based filtering. So what remains is a minor fixup for video.

## Codex Notes
### Motivation
- Ensure DASH video segments use a consistent threshold chosen at the start of the group instead of relying on a global background threshold so scans for later segments remain consistent with the initiating request.
- Prevent subsequent segments from unexpectedly using a different threshold after zone changes or other background updates.
- Note that other places still reference global thresholds (e.g. GIF handling, processor code and background.js) and will require matching per-request refactors to complete the migration.

### Description
- Added a `threshold` parameter to `vidCheckCreateDashGroup` and record the threshold on newly created DASH groups.
- When an existing group is observed without a recorded threshold, populate `dashGroup.threshold` from the current request so the group's threshold is set once when first seen.
- Use the group-specific threshold (`dashGroup.threshold ?? threshold`) when calling `vidPerformVideoScan` so all segment scans for the same group reuse the stored threshold.
- Limited scope: changes are confined to `background_video.js`; other files still need equivalent per-request threshold wiring for a full client/server migration.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d81295f6c83309903fb6631439707)