### PR TITLE
Add per-site adaptive thresholds, media stats store, and per-tab status visuals

### DIFF
--- a/background.js
+++ b/background.js
@@ -225,13 +225,12 @@ function bkOnProcessorMessage(m) {
             statusCompleteImageCheck(m.requestId, m.result, tabId);
             BK_requestIdToTabId.delete(m.requestId);
             if (m.opaque && m.opaque.type !== 'pseudo') {
-                let linearScore = rocEstimateLinearScoreAtThreshold(m.rocScore);
                 ssAddRequestRecord({
                     timestamp: Date.now(),
                     pageHost: m.opaque.pageHost,
                     contentHost: m.opaque.contentHost,
                     threshold: m.opaque.threshold,
-                    linearScore: linearScore,
+                    rocScore: m.rocScore,
                     modelVersion: ssGetModelVersion()
                 });
                 if (tabId !== null) {

--- a/background.js
+++ b/background.js
@@ -196,6 +196,20 @@ function bkOnProcessorMessage(m) {
                 filter.close();
                 delete BK_openFilters[m.requestId];
                 WJR_DEBUG && console.debug('OPEN FILTERS: '+Object.keys(BK_openFilters).length);
+                if (m.opaque && m.opaque.type !== 'pseudo' && m.sqrxrScore) {
+                    ssAddRequestRecord({
+                        timestamp: Date.now(),
+                        pageHost: m.opaque.pageHost,
+                        contentHost: m.opaque.contentHost,
+                        threshold: m.opaque.threshold,
+                        rocScore: m.sqrxrScore[0][0],
+                        modelVersion: ssGetModelVersion()
+                    });
+                    let tabId = bkGetTabIdForRequest(m.requestId);
+                    if (tabId !== null) {
+                        bkUpdateTabVisuals(tabId);
+                    }
+                }
             }
         }
             break;
@@ -224,19 +238,6 @@ function bkOnProcessorMessage(m) {
             let tabId = bkGetTabIdForRequest(m.requestId);
             statusCompleteImageCheck(m.requestId, m.result, tabId);
             BK_requestIdToTabId.delete(m.requestId);
-            if (m.opaque && m.opaque.type !== 'pseudo') {
-                ssAddRequestRecord({
-                    timestamp: Date.now(),
-                    pageHost: m.opaque.pageHost,
-                    contentHost: m.opaque.contentHost,
-                    threshold: m.opaque.threshold,
-                    rocScore: m.rocScore,
-                    modelVersion: ssGetModelVersion()
-                });
-                if (tabId !== null) {
-                    bkUpdateTabVisuals(tabId);
-                }
-            }
         }
             break;
         case 'registration': {

--- a/background.js
+++ b/background.js
@@ -28,6 +28,7 @@ let BK_connectedClients = {};
 let BK_openFilters = {};
 let BK_openB64Filters = {};
 let BK_openVidFilters = {};
+const BK_requestIdToTabId = new Map();
 
 const BK_revealAllowlist = new Set();
 const BK_revealAllowlistQueue = [];
@@ -103,6 +104,36 @@ function bkBroadcastProcessorSettings() {
 
 browser.runtime.onConnect.addListener(bkOnClientConnected);
 
+function bkExtractRootDomain(url) {
+    try {
+        let parsedUrl = new URL(url);
+        let parts = parsedUrl.hostname.split('.');
+        if (parts.length <= 2) {
+            return parsedUrl.hostname;
+        }
+        let root = parts[parts.length - 2] + '.' + parts[parts.length - 1];
+        if (parts[parts.length - 2].length == 2) {
+            root = parts[parts.length - 3] + '.' + root;
+        }
+        return root;
+    } catch (ex) {
+        console.warn('SO: Could not extract root domain because ' + ex + ' for ' + url);
+        return 'undefined';
+    }
+}
+
+function bkGetTopmostUrl(details) {
+    let result = 'undefined';
+    if (details.frameAncestors !== undefined && details.frameAncestors.length > 0) {
+        result = details.frameAncestors[details.frameAncestors.length - 1].url;
+    } else if (details.documentUrl) {
+        result = details.documentUrl;
+    } else {
+        result = details.originUrl;
+    }
+    return result;
+}
+
 
 let BK_processorBackendPreference = [];
 
@@ -142,6 +173,16 @@ function bkReloadProcessors() {
     WJR_DEBUG && console.log('LIFECYCLE: New processors are launching!');
 }
 
+function bkGetTabIdForRequest(requestId) {
+    if (BK_requestIdToTabId.has(requestId)) {
+        return BK_requestIdToTabId.get(requestId);
+    }
+    let prefix = requestId.split('_')[0];
+    if (BK_requestIdToTabId.has(prefix)) {
+        return BK_requestIdToTabId.get(prefix);
+    }
+    return null;
+}
 
 function bkOnProcessorMessage(m) {
     switch (m.type) {
@@ -180,16 +221,21 @@ function bkOnProcessorMessage(m) {
             break;
         case 'stat': {
             WJR_DEBUG && console.debug('STAT: '+m.requestId+' '+m.result);
-            statusCompleteImageCheck(m.requestId, m.result);
-            switch (m.result) {
-                case 'pass': {
-                    bkIncrementPassCount();
+            let tabId = bkGetTabIdForRequest(m.requestId);
+            statusCompleteImageCheck(m.requestId, m.result, tabId);
+            BK_requestIdToTabId.delete(m.requestId);
+            if (m.opaque && m.opaque.type !== 'pseudo') {
+                ssAddRequestRecord({
+                    timestamp: Date.now(),
+                    pageHost: m.opaque.pageHost,
+                    contentHost: m.opaque.contentHost,
+                    threshold: m.opaque.threshold,
+                    rocScore: m.rocScore,
+                    modelVersion: ssGetModelVersion()
+                });
+                if (tabId !== null) {
+                    bkUpdateTabVisuals(tabId);
                 }
-                    break;
-                case 'block': {
-                    bkIncrementBlockCount();
-                }
-                //could also be tiny or error
             }
         }
             break;
@@ -204,123 +250,87 @@ function bkOnProcessorMessage(m) {
 }
 
 /////////// ZONE START /////////////////////////
-var BK_isZoneAutomatic = true;
-var BK_predictionBufferBlockCount = 0;
-var BK_predictionBuffer = [];
-var BK_estimatedTruePositivePercentage = 0;
-var BK_isEstimateValid = false;
-
-function bkAddToPredictionBuffer(prediction) {
-    BK_predictionBuffer.push(prediction);
-    if (prediction > 0) {
-        BK_predictionBufferBlockCount++;
-    }
-    if (BK_predictionBuffer.length > 200) {
-        let oldPrediction = BK_predictionBuffer.shift();
-        if (oldPrediction > 0) {
-            BK_predictionBufferBlockCount--;
-        }
-    }
-    if (BK_predictionBuffer.length > 50) {
-        let estimatedTruePositiveCount = BK_zonePrecision * BK_predictionBufferBlockCount;
-        BK_estimatedTruePositivePercentage = estimatedTruePositiveCount / BK_predictionBuffer.length;
-        BK_isEstimateValid = true;
-    } else {
-        BK_estimatedTruePositivePercentage = 0;
-        BK_isEstimateValid = false;
-    }
-}
-
-function bkClearPredictionBuffer() {
-    BK_predictionBufferBlockCount = 0;
-    BK_predictionBuffer = [];
-    BK_estimatedTruePositivePercentage = 0;
-}
-
-function bkIncrementBlockCount() {
-    bkAddToPredictionBuffer(1);
-    bkCheckZone();
-}
-
-function bkIncrementPassCount() {
-    bkAddToPredictionBuffer(0);
-    bkCheckZone();
-}
-
-function bkSetZoneAutomatic(isAutomatic) {
-    BK_isZoneAutomatic = isAutomatic;
-}
+const BK_siteSettings = new Map();
+let BK_defaultZone = 'neutral';
+let BK_defaultIsAutomatic = true;
 
 function bkSetDefaultZone(result) {
-    console.log('result');
-    console.log(result);
     if (!result.default_zone || result.default_zone === 'automatic') {
-        bkSetZoneAutomatic(true);
-        BK_zone = 'neutral'
+        BK_defaultIsAutomatic = true;
+        BK_defaultZone = 'neutral';
     } else {
-        bkSetZoneAutomatic(false);
-        BK_zone = result.default_zone;
+        BK_defaultIsAutomatic = false;
+        BK_defaultZone = result.default_zone;
     }
 }
 
-function bkCheckZone() {
-    if (!BK_isEstimateValid) {
-        return;
+function bkGetSiteSettings(pageHost) {
+    if (!pageHost || pageHost === 'undefined') {
+        return { zone: BK_defaultZone, isAutomatic: BK_defaultIsAutomatic };
     }
-    if (!BK_isZoneAutomatic) {
-        return;
+    let settings = BK_siteSettings.get(pageHost);
+    if (!settings) {
+        settings = { zone: BK_defaultZone, isAutomatic: BK_defaultIsAutomatic };
+        BK_siteSettings.set(pageHost, settings);
     }
-    let requestedZone = 'untrusted';
-    if (BK_estimatedTruePositivePercentage < ROC_trustedToNeutralPercentage) {
-        requestedZone = 'trusted';
-    } else if (BK_estimatedTruePositivePercentage < ROC_neutralToUntrustedPercentage) {
-        requestedZone = 'neutral';
-    }
-    if (requestedZone != BK_zone) {
-        bkSetZone(requestedZone);
-    }
+    return settings;
 }
 
-
-
-var BK_zoneThreshold = ROC_neutralRoc.threshold;
-var BK_zonePrecision = rocCalculatePrecision(ROC_neutralRoc);
-WJR_DEBUG && console.log("Zone precision is: "+BK_zonePrecision);
-var BK_zone = 'neutral';
-function bkSetZone(newZone)
-{
-    WJR_DEBUG && console.log('Zone request to: '+newZone);
-    let didZoneChange = false;
-    switch (newZone) {
+function bkZoneToThreshold(zone) {
+    switch (zone) {
         case 'trusted':
-            BK_zoneThreshold = ROC_trustedRoc.threshold;
-            BK_zonePrecision = rocCalculatePrecision(ROC_trustedRoc);
-            statusSetImageZoneTrusted();
-            BK_zone = newZone;
-            didZoneChange = true;
-            WJR_DEBUG && console.log('Zone is now trusted!');
-            break;
-        case 'neutral':
-            BK_zoneThreshold = ROC_neutralRoc.threshold;
-            BK_zonePrecision = rocCalculatePrecision(ROC_neutralRoc);
-            statusSetImageZoneNeutral();
-            BK_zone = newZone;
-            didZoneChange = true;
-            WJR_DEBUG && console.log('Zone is now neutral!');
-            break;
+            return ROC_trustedRoc.threshold;
         case 'untrusted':
-            BK_zoneThreshold = ROC_untrustedRoc.threshold;
-            BK_zonePrecision = rocCalculatePrecision(ROC_untrustedRoc);
-            statusSetImageZoneUntrusted();
-            BK_zone = newZone;
-            didZoneChange = true;
-            WJR_DEBUG && console.log('Zone is now untrusted!')
-            break;
+            return ROC_untrustedRoc.threshold;
+        default:
+            return ROC_neutralRoc.threshold;
     }
-    if(didZoneChange) {
-        WJR_DEBUG && console.log("Zone precision is: "+BK_zonePrecision);
-        bkClearPredictionBuffer();
+}
+
+function bkThresholdToZone(threshold) {
+    if (threshold >= ROC_trustedRoc.threshold) {
+        return 'trusted';
     }
+    if (threshold >= ROC_neutralRoc.threshold) {
+        return 'neutral';
+    }
+    return 'untrusted';
+}
+
+function bkSetZoneForHost(pageHost, newZone) {
+    let settings = bkGetSiteSettings(pageHost);
+    settings.zone = newZone;
+    settings.isAutomatic = false;
+    BK_siteSettings.set(pageHost, settings);
+}
+
+function bkSetZoneAutomaticForHost(pageHost, isAutomatic) {
+    let settings = bkGetSiteSettings(pageHost);
+    settings.isAutomatic = isAutomatic;
+    BK_siteSettings.set(pageHost, settings);
+}
+
+function bkGetZoneForHost(pageHost) {
+    let settings = bkGetSiteSettings(pageHost);
+    if (settings.isAutomatic) {
+        let threshold = bkPickThreshold(pageHost, settings);
+        return bkThresholdToZone(threshold);
+    }
+    return settings.zone;
+}
+
+function bkPickThreshold(pageHost, settings = null) {
+    let resolved = settings ?? bkGetSiteSettings(pageHost);
+    if (resolved.isAutomatic) {
+        return ssSuggestAdaptiveThreshold(
+            pageHost,
+            ROC_neutralRoc.threshold,
+            0.025,
+            ROC_untrustedRoc.threshold,
+            ROC_trustedRoc.threshold
+        );
+    }
+    return bkZoneToThreshold(resolved.zone);
 }
 
 ////////////////////// ZONE END //////////////////////////
@@ -405,7 +415,8 @@ async function bkCrashDetectionWatchdog() {
             requestId: pseudoRequestId,
             mimeType: 'image/jpeg',
             url: pseudoRequestId,
-            threshold: BK_zoneThreshold
+            threshold: bkZoneToThreshold(BK_defaultZone),
+            opaque: { type: 'pseudo' }
         });
         processor.postMessage({
             type: 'ondata',
@@ -577,14 +588,24 @@ async function bkImageListenerNormal(details, mimeType) {
     let filter = browser.webRequest.filterResponseData(details.requestId);
 
     let processor = bkGetNextProcessor().port;
+    let pageHost = bkExtractRootDomain(bkGetTopmostUrl(details));
+    let contentHost = bkExtractRootDomain(details.url);
+    let threshold = bkPickThreshold(pageHost);
     processor.postMessage({
         type: 'start',
         requestId: details.requestId,
         mimeType: mimeType,
         url: details.url,
-        threshold: BK_zoneThreshold
+        threshold: threshold,
+        opaque: {
+            type: 'normal',
+            pageHost: pageHost,
+            contentHost: contentHost,
+            threshold: threshold
+        }
     });
-    statusStartImageCheck(details.requestId);
+    BK_requestIdToTabId.set(details.requestId, details.tabId);
+    statusStartImageCheck(details.requestId, details.tabId);
 
     filter.ondata = event => {
         if (dataStartTime == null) {
@@ -691,11 +712,20 @@ async function bkBase64ContentListener(details) {
 
     //Choose highest power here because we have many images possibly
     let processor = bkGetNextProcessor().port;
+    let pageHost = bkExtractRootDomain(bkGetTopmostUrl(details));
+    let threshold = bkPickThreshold(pageHost);
     processor.postMessage({
         type: 'b64_start',
         requestId: details.requestId,
-        threshold: BK_zoneThreshold
+        threshold: threshold,
+        opaque: {
+            type: 'b64',
+            pageHost: pageHost,
+            contentHost: pageHost,
+            threshold: threshold
+        }
     });
+    BK_requestIdToTabId.set(details.requestId, details.tabId);
 
     filter.ondata = evt => {
         let str = decoder.decode(evt.data, { stream: true });
@@ -1113,6 +1143,74 @@ if (browser.menus) {
     });
 }
 
+/////////////////////Active Tab Management///////////////////////////
+
+function bkApplyZoneToTab(tabId, zone) {
+    switch (zone) {
+        case 'trusted':
+            statusSetImageZoneTrusted(tabId);
+            break;
+        case 'neutral':
+            statusSetImageZoneNeutral(tabId);
+            break;
+        case 'untrusted':
+            statusSetImageZoneUntrusted(tabId);
+            break;
+    }
+}
+
+function bkUpdateTabVisuals(tabId, tabUrl = null) {
+    if (!tabId) {
+        return;
+    }
+    let apply = url => {
+        if (!url || !url.startsWith('http')) {
+            return;
+        }
+        let pageHost = bkExtractRootDomain(url);
+        let zone = bkGetZoneForHost(pageHost);
+        bkApplyZoneToTab(tabId, zone);
+        statusUpdateVisuals(tabId);
+    };
+    if (tabUrl) {
+        apply(tabUrl);
+        return;
+    }
+    browser.tabs.get(tabId)
+        .then(tab => apply(tab.url))
+        .catch(error => {
+            WJR_DEBUG && console.warn('TAB: Unable to update tab visuals', error);
+        });
+}
+
+function bkUpdateActiveTabVisuals() {
+    browser.tabs.query({ active: true, currentWindow: true })
+        .then(tabs => {
+            if (tabs[0]) {
+                bkUpdateTabVisuals(tabs[0].id, tabs[0].url);
+            }
+        })
+        .catch(error => {
+            WJR_DEBUG && console.warn('TAB: Unable to query active tab', error);
+        });
+}
+
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.url || changeInfo.status === 'complete') {
+        bkUpdateTabVisuals(tabId, tab.url);
+    }
+});
+
+browser.tabs.onActivated.addListener(activeInfo => {
+    bkUpdateTabVisuals(activeInfo.tabId);
+});
+
+browser.windows.onFocusChanged.addListener(() => {
+    bkUpdateActiveTabVisuals();
+});
+
+bkUpdateActiveTabVisuals();
+
 ////////////////////////Actual Startup//////////////////////////////
 
 function bkRegisterAllCallbacks() {
@@ -1273,18 +1371,41 @@ function bkSetAllLogging(onOrOff) {
     bkBroadcastMessageToProcessors({ "type": "set_all_logging", "value" : onOrOff});
 }
 
+function bkGetPageHostFromMessage(request, sender) {
+    let url = request.pageUrl || request.url || sender?.tab?.url;
+    if (!url) {
+        return 'undefined';
+    }
+    return bkExtractRootDomain(url);
+}
+
 function bkHandleMessage(request, sender, sendResponse) {
     if (request.type == 'setZone') {
-        bkSetZone(request.zone);
+        let pageHost = bkGetPageHostFromMessage(request, sender);
+        bkSetZoneForHost(pageHost, request.zone);
+        if (sender?.tab?.id) {
+            bkUpdateTabVisuals(sender.tab.id);
+        } else {
+            bkUpdateActiveTabVisuals();
+        }
     }
     else if (request.type == 'getZone') {
-        sendResponse({ zone: BK_zone });
+        let pageHost = bkGetPageHostFromMessage(request, sender);
+        sendResponse({ zone: bkGetZoneForHost(pageHost) });
     }
     else if (request.type == 'setZoneAutomatic') {
-        bkSetZoneAutomatic(request.isZoneAutomatic);
+        let pageHost = bkGetPageHostFromMessage(request, sender);
+        bkSetZoneAutomaticForHost(pageHost, request.isZoneAutomatic);
+        if (sender?.tab?.id) {
+            bkUpdateTabVisuals(sender.tab.id);
+        } else {
+            bkUpdateActiveTabVisuals();
+        }
     }
     else if (request.type == 'getZoneAutomatic') {
-        sendResponse({ isZoneAutomatic: BK_isZoneAutomatic });
+        let pageHost = bkGetPageHostFromMessage(request, sender);
+        let settings = bkGetSiteSettings(pageHost);
+        sendResponse({ isZoneAutomatic: settings.isAutomatic });
     }
     else if (request.type == 'getOnOff') {
         sendResponse({ onOff: BK_isEnabled ? 'on' : 'off' });
@@ -1319,9 +1440,6 @@ function bkHandleMessage(request, sender, sendResponse) {
 browser.runtime.onMessage.addListener(bkHandleMessage);
 browser.storage.local.get('default_zone')
     .then(bkSetDefaultZone)
-    .then(() => {
-        bkSetZone(BK_zone);
-    })
     .then(() => {
         bkLoadBackendSettings(); //The loading of the first processor kicks off the rest of initialization
     });

--- a/background.js
+++ b/background.js
@@ -225,12 +225,13 @@ function bkOnProcessorMessage(m) {
             statusCompleteImageCheck(m.requestId, m.result, tabId);
             BK_requestIdToTabId.delete(m.requestId);
             if (m.opaque && m.opaque.type !== 'pseudo') {
+                let linearScore = rocEstimateLinearScoreAtThreshold(m.rocScore);
                 ssAddRequestRecord({
                     timestamp: Date.now(),
                     pageHost: m.opaque.pageHost,
                     contentHost: m.opaque.contentHost,
                     threshold: m.opaque.threshold,
-                    rocScore: m.rocScore,
+                    linearScore: linearScore,
                     modelVersion: ssGetModelVersion()
                 });
                 if (tabId !== null) {

--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,7 @@
           "silent_mode.js",
           "processor.js",
           "processor_backgroundstartup.js",
-          "media_stats_store.js",
+          "site_store.js",
 
           "background.js",
           "background_video.js",

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
       "menus",
       "proxy",
       "storage",
+      "tabs",
       "tabHide",
       "idle",
       "contextMenus"
@@ -41,6 +42,7 @@
           "silent_mode.js",
           "processor.js",
           "processor_backgroundstartup.js",
+          "media_stats_store.js",
 
           "background.js",
           "background_video.js",

--- a/media_stats_store.js
+++ b/media_stats_store.js
@@ -1,0 +1,65 @@
+const SS_MAX_RECORDS = 10000;
+const SS_MODEL_VERSION = 'SQRXR112';
+const SS_records = [];
+let SS_nextKey = 1;
+
+function ssGetModelVersion() {
+    return SS_MODEL_VERSION;
+}
+
+function ssAddRequestRecord(record) {
+    if (!record || record.rocScore === null || record.rocScore === undefined) {
+        return;
+    }
+    const entry = {
+        timestamp: record.timestamp ?? Date.now(),
+        pageHost: record.pageHost,
+        contentHost: record.contentHost,
+        threshold: record.threshold,
+        rocScore: record.rocScore,
+        modelVersion: record.modelVersion ?? SS_MODEL_VERSION,
+        key: SS_nextKey++
+    };
+    SS_records.push(entry);
+    if (SS_records.length > SS_MAX_RECORDS) {
+        SS_records.shift();
+    }
+}
+
+function ssGetScoresForPageHost(pageHost) {
+    const scores = [];
+    for (let i = 0; i < SS_records.length; i++) {
+        if (SS_records[i].pageHost === pageHost) {
+            scores.push(SS_records[i].rocScore);
+        }
+    }
+    return scores;
+}
+
+function ssSuggestAdaptiveThreshold(pageHost, fallbackThreshold, fallbackStdDev, minThreshold, maxThreshold) {
+    const scores = ssGetScoresForPageHost(pageHost);
+    if (scores.length < 50) {
+        return fallbackThreshold;
+    }
+
+    let sum = 0;
+    for (let i = 0; i < scores.length; i++) {
+        sum += scores[i];
+    }
+    const mean = sum / scores.length;
+
+    let varianceSum = 0;
+    for (let i = 0; i < scores.length; i++) {
+        let delta = scores[i] - mean;
+        varianceSum += delta * delta;
+    }
+    const stddev = Math.sqrt(varianceSum / Math.max(scores.length - 1, 1));
+
+    const scaleFactor = 2 + 30.0 / Math.pow(scores.length, 1.5);
+    const pushFromMean = Math.max(stddev * scaleFactor, fallbackStdDev * 3);
+    const suggested = mean + pushFromMean;
+
+    let threshold = Math.min(suggested, maxThreshold);
+    threshold = Math.max(threshold, minThreshold);
+    return threshold;
+}

--- a/popup.js
+++ b/popup.js
@@ -1,14 +1,26 @@
 window.onload=function()
 {
+    let activeTabUrlPromise = browser.tabs.query({ active: true, currentWindow: true })
+        .then(tabs => tabs[0]?.url ?? null);
     let rad = document.getElementById('popupForm').zone;
     for (var i = 0; i < rad.length; i++) {
         rad[i].addEventListener('change', function(e) {
-            browser.runtime.sendMessage({ type: 'setZone', zone: e.target.id });
-            browser.runtime.sendMessage({ type: 'setZoneAutomatic', isZoneAutomatic: false });
+            activeTabUrlPromise.then(pageUrl => {
+                if (!pageUrl) {
+                    return;
+                }
+                browser.runtime.sendMessage({ type: 'setZone', zone: e.target.id, pageUrl });
+                browser.runtime.sendMessage({ type: 'setZoneAutomatic', isZoneAutomatic: false, pageUrl });
+            });
             window.close();
         });
     }
-    let sending = browser.runtime.sendMessage({type:'getZone'});
+    let sending = activeTabUrlPromise.then(pageUrl => {
+        if (!pageUrl) {
+            throw new Error('No active tab URL');
+        }
+        return browser.runtime.sendMessage({type:'getZone', pageUrl});
+    });
     sending.then(
         function(message)
         {
@@ -22,10 +34,20 @@ window.onload=function()
     )
     let autoBox = document.getElementById('popupForm').zoneAuto;
     autoBox.addEventListener('change', function(e) {
-        browser.runtime.sendMessage({ type: 'setZoneAutomatic', isZoneAutomatic: e.target.checked });
+        activeTabUrlPromise.then(pageUrl => {
+            if (!pageUrl) {
+                return;
+            }
+            browser.runtime.sendMessage({ type: 'setZoneAutomatic', isZoneAutomatic: e.target.checked, pageUrl });
+        });
         window.close();
     });
-    let automatic = browser.runtime.sendMessage({type:'getZoneAutomatic'});
+    let automatic = activeTabUrlPromise.then(pageUrl => {
+        if (!pageUrl) {
+            throw new Error('No active tab URL');
+        }
+        return browser.runtime.sendMessage({type:'getZoneAutomatic', pageUrl});
+    });
     automatic.then(
         function(message)
         {

--- a/processor.js
+++ b/processor.js
@@ -274,10 +274,6 @@ function procScoreToStr(sqrxrScore) {
         sqrxrScore[1][3].toFixed(2)+')';
 }
 
-function procGetRocScore(sqrxrScore) {
-    return sqrxrScore?.[0]?.[0] ?? null;
-}
-
 function procIsSafe(sqrxrScore, threshold) {
     return sqrxrScore[0][0] < threshold;
 }
@@ -298,7 +294,6 @@ async function procPerformFiltering(entry) {
         requestId: entry.requestId,
         imageBytes: null,
         result: null,
-        rocScore: null,
         opaque: entry.opaque
     };
     let byteCount = 0;
@@ -317,11 +312,11 @@ async function procPerformFiltering(entry) {
                 WJR_DEBUG && console.debug('ML: predict '+entry.requestId+' size '+img.width+'x'+img.height+', materialization occured with '+byteCount+' bytes');
                 let imgLoadTime = performance.now();
                 let sqrxrScore = await procPredict(img);
-                result.rocScore = procGetRocScore(sqrxrScore);
                 if(procIsSafe(sqrxrScore, entry.threshold)) {
                     WJR_DEBUG && console.log('ML: Passed: '+procScoreToStr(sqrxrScore)+' '+entry.requestId);
                     result.result = 'pass';
                     result.imageBytes = await blob.arrayBuffer();
+                    result.sqrxrScore = sqrxrScore;
                 } else {
                     WJR_DEBUG && console.log('ML: Blocked: '+procScoreToStr(sqrxrScore)+' '+entry.requestId);
                     let svgText = await procCommonCreateSvgFromBlob(img, sqrxrScore, blob);
@@ -426,12 +421,10 @@ async function procCompleteB64Filtering(b64Filter, outputPort) {
                     let sqrxrScore = await procPredict(img);
                     WJR_DEBUG && console.debug('ML: base64 score: '+procScoreToStr(sqrxrScore));
                     let replacement = null; //safe
-                    let rocScore = procGetRocScore(sqrxrScore);
                     if(procIsSafe(sqrxrScore, b64Filter.threshold)) {
                         outputPort.postMessage({
                             type:'stat',
                             result:'pass',
-                            rocScore: rocScore,
                             requestId: b64Filter.requestId+'_'+imageId,
                             opaque: b64Filter.opaque
                         });
@@ -440,7 +433,6 @@ async function procCompleteB64Filtering(b64Filter, outputPort) {
                         outputPort.postMessage({
                             type:'stat',
                             result:'block',
-                            rocScore: rocScore,
                             requestId: b64Filter.requestId+'_'+imageId,
                             opaque: b64Filter.opaque
                         });
@@ -464,7 +456,6 @@ async function procCompleteB64Filtering(b64Filter, outputPort) {
                     outputPort.postMessage({
                         type:'stat',
                         result:'tiny',
-                        rocScore: null,
                         requestId: b64Filter.requestId+'_'+imageId,
                         opaque: b64Filter.opaque
                     });
@@ -476,7 +467,6 @@ async function procCompleteB64Filtering(b64Filter, outputPort) {
                 outputPort.postMessage({
                     type:'stat',
                     result:'error',
-                    rocScore: null,
                     requestId: b64Filter.requestId+'_'+imageId,
                     opaque: b64Filter.opaque
                 });
@@ -546,7 +536,6 @@ async function procCheckProcess() {
             PROC_port.postMessage({
                 type:'stat',
                 result: result.result,
-                rocScore: result.rocScore,
                 requestId: toProcess.requestId,
                 opaque: result.opaque
             });
@@ -782,7 +771,6 @@ async function procOnPortMessage(m) {
             PROC_port.postMessage({
                 type:'stat',
                 result: 'error',
-                rocScore: null,
                 requestId: m.requestId,
                 opaque: failedRequest?.opaque
             });

--- a/processor.js
+++ b/processor.js
@@ -274,6 +274,10 @@ function procScoreToStr(sqrxrScore) {
         sqrxrScore[1][3].toFixed(2)+')';
 }
 
+function procGetRocScore(sqrxrScore) {
+    return sqrxrScore?.[0]?.[0] ?? null;
+}
+
 function procIsSafe(sqrxrScore, threshold) {
     return sqrxrScore[0][0] < threshold;
 }
@@ -293,7 +297,9 @@ async function procPerformFiltering(entry) {
         type: 'scan',
         requestId: entry.requestId,
         imageBytes: null,
-        result: null
+        result: null,
+        rocScore: null,
+        opaque: entry.opaque
     };
     let byteCount = 0;
     for(let i=0; i<entry.buffers.length; i++) {
@@ -311,11 +317,11 @@ async function procPerformFiltering(entry) {
                 WJR_DEBUG && console.debug('ML: predict '+entry.requestId+' size '+img.width+'x'+img.height+', materialization occured with '+byteCount+' bytes');
                 let imgLoadTime = performance.now();
                 let sqrxrScore = await procPredict(img);
+                result.rocScore = procGetRocScore(sqrxrScore);
                 if(procIsSafe(sqrxrScore, entry.threshold)) {
                     WJR_DEBUG && console.log('ML: Passed: '+procScoreToStr(sqrxrScore)+' '+entry.requestId);
                     result.result = 'pass';
                     result.imageBytes = await blob.arrayBuffer();
-                    result.sqrxrScore = sqrxrScore;
                 } else {
                     WJR_DEBUG && console.log('ML: Blocked: '+procScoreToStr(sqrxrScore)+' '+entry.requestId);
                     let svgText = await procCommonCreateSvgFromBlob(img, sqrxrScore, blob);
@@ -420,18 +426,23 @@ async function procCompleteB64Filtering(b64Filter, outputPort) {
                     let sqrxrScore = await procPredict(img);
                     WJR_DEBUG && console.debug('ML: base64 score: '+procScoreToStr(sqrxrScore));
                     let replacement = null; //safe
+                    let rocScore = procGetRocScore(sqrxrScore);
                     if(procIsSafe(sqrxrScore, b64Filter.threshold)) {
                         outputPort.postMessage({
                             type:'stat',
                             result:'pass',
-                            requestId: b64Filter.requestId+'_'+imageId
+                            rocScore: rocScore,
+                            requestId: b64Filter.requestId+'_'+imageId,
+                            opaque: b64Filter.opaque
                         });
                         WJR_DEBUG && console.log('ML: base64 filter Passed: '+procScoreToStr(sqrxrScore)+' '+b64Filter.requestId);
                     } else {
                         outputPort.postMessage({
                             type:'stat',
                             result:'block',
-                            requestId: b64Filter.requestId+'_'+imageId
+                            rocScore: rocScore,
+                            requestId: b64Filter.requestId+'_'+imageId,
+                            opaque: b64Filter.opaque
                         });
                         let svgText = await procCommonCreateSvg(img,sqrxrScore,img.src);
                         let svgURI='data:image/svg+xml;base64,'+window.btoa(svgText);
@@ -453,7 +464,9 @@ async function procCompleteB64Filtering(b64Filter, outputPort) {
                     outputPort.postMessage({
                         type:'stat',
                         result:'tiny',
-                        requestId: b64Filter.requestId+'_'+imageId
+                        rocScore: null,
+                        requestId: b64Filter.requestId+'_'+imageId,
+                        opaque: b64Filter.opaque
                     });
                     WJR_DEBUG && console.debug('WEBREQ: base64 skipping image with small dimensions: '+imageId);
                 }
@@ -463,7 +476,9 @@ async function procCompleteB64Filtering(b64Filter, outputPort) {
                 outputPort.postMessage({
                     type:'stat',
                     result:'error',
-                    requestId: b64Filter.requestId+'_'+imageId
+                    rocScore: null,
+                    requestId: b64Filter.requestId+'_'+imageId,
+                    opaque: b64Filter.opaque
                 });
                 console.error('WEBREQ: base64 check failure for '+imageId+': '+e);
             }
@@ -531,7 +546,9 @@ async function procCheckProcess() {
             PROC_port.postMessage({
                 type:'stat',
                 result: result.result,
-                requestId: toProcess.requestId
+                rocScore: result.rocScore,
+                requestId: toProcess.requestId,
+                opaque: result.opaque
             });
         } catch(e) {
             console.error('ERROR: Processor failed to communicate to background: '+e);
@@ -747,6 +764,7 @@ async function procOnPortMessage(m) {
                 url: m.url,
                 mimeType: m.mimeType,
                 threshold: m.threshold,
+                opaque: m.opaque,
                 startTime: performance.now(),
                 buffers: []
             };
@@ -759,11 +777,14 @@ async function procOnPortMessage(m) {
         }
         break;
         case 'onerror': {
+            let failedRequest = PROC_openRequests[m.requestId];
             delete PROC_openRequests[m.requestId];
             PROC_port.postMessage({
                 type:'stat',
                 result: 'error',
-                requestId: m.requestId
+                rocScore: null,
+                requestId: m.requestId,
+                opaque: failedRequest?.opaque
             });
         }
         break;
@@ -796,6 +817,7 @@ async function procOnPortMessage(m) {
             PROC_openB64Requests[m.requestId] = {
                 requestId: m.requestId,
                 threshold: m.threshold,
+                opaque: m.opaque,
                 startTime: performance.now(),
                 fullStr: ''
             };

--- a/roc.js
+++ b/roc.js
@@ -13,6 +13,37 @@ function rocFindConfidence(threshold) {
     return 1.0-bestMatch.tpr;
 }
 
+// Converts a raw ROC threshold into an approximately linear "risk" score.
+// We approximate balanced error rate: (FPR + FNR) / 2 using linear interpolation
+// across adjacent ROC entries to smooth between sample thresholds.
+function rocEstimateLinearScoreAtThreshold(threshold) {
+    if (threshold === null || threshold === undefined) {
+        return null;
+    }
+    if (!ROC_VALUES || ROC_VALUES.length === 0) {
+        return null;
+    }
+    let lower = ROC_VALUES[ROC_VALUES.length - 1];
+    let upper = ROC_VALUES[0];
+    for (let i = 0; i < ROC_VALUES.length; i++) {
+        if (ROC_VALUES[i].threshold < threshold) {
+            lower = ROC_VALUES[i];
+            upper = ROC_VALUES[Math.max(i - 1, 0)];
+            break;
+        }
+    }
+    if (upper.threshold === lower.threshold) {
+        let fpr = lower.fpr;
+        let fnr = 1.0 - lower.tpr;
+        return (fpr + fnr) / 2.0;
+    }
+    let ratio = (threshold - lower.threshold) / (upper.threshold - lower.threshold);
+    let fpr = lower.fpr + (upper.fpr - lower.fpr) * ratio;
+    let tpr = lower.tpr + (upper.tpr - lower.tpr) * ratio;
+    let fnr = 1.0 - tpr;
+    return (fpr + fnr) / 2.0;
+}
+
 function rocFindRocEntryByFpr(desiredFPR) {
     let bestMatch = ROC_VALUES[0];
     for(let i=ROC_VALUES.length-1; i>=0; i--) {

--- a/roc.js
+++ b/roc.js
@@ -44,6 +44,29 @@ function rocEstimateLinearScoreAtThreshold(threshold) {
     return (fpr + fnr) / 2.0;
 }
 
+// Inverse lookup: pick the ROC threshold that best matches a target linear score.
+function rocFindThresholdForLinearScore(targetLinearScore) {
+    if (targetLinearScore === null || targetLinearScore === undefined) {
+        return null;
+    }
+    if (!ROC_VALUES || ROC_VALUES.length === 0) {
+        return null;
+    }
+    let bestThreshold = ROC_VALUES[0].threshold;
+    let bestDelta = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < ROC_VALUES.length; i++) {
+        let entry = ROC_VALUES[i];
+        let fnr = 1.0 - entry.tpr;
+        let linearScore = (entry.fpr + fnr) / 2.0;
+        let delta = Math.abs(linearScore - targetLinearScore);
+        if (delta < bestDelta) {
+            bestDelta = delta;
+            bestThreshold = entry.threshold;
+        }
+    }
+    return bestThreshold;
+}
+
 function rocFindRocEntryByFpr(desiredFPR) {
     let bestMatch = ROC_VALUES[0];
     for(let i=ROC_VALUES.length-1; i>=0; i--) {

--- a/site_store.js
+++ b/site_store.js
@@ -79,9 +79,10 @@ function ssSuggestAdaptiveThreshold(pageHost, fallbackThreshold, fallbackStdDev,
 
     const scaleFactor = 1 + 8.0 / Math.pow(scores.length, 0.75);
     const pushFromMean = Math.max(stddev * scaleFactor, fallbackStdDev * 2);
-    const suggested = mean + pushFromMean;
+    const suggestedLinear = mean + pushFromMean;
+    const mappedThreshold = rocFindThresholdForLinearScore(suggestedLinear);
 
-    let threshold = Math.min(suggested, maxThreshold);
+    let threshold = Math.min(mappedThreshold ?? suggestedLinear, maxThreshold);
     threshold = Math.max(threshold, minThreshold);
     console.info('[SS] threshold_calc ' + JSON.stringify({
         pageHost: pageHost,
@@ -90,7 +91,8 @@ function ssSuggestAdaptiveThreshold(pageHost, fallbackThreshold, fallbackStdDev,
         stddev: stddev,
         scaleFactor: scaleFactor,
         pushFromMean: pushFromMean,
-        suggested: suggested,
+        suggestedLinear: suggestedLinear,
+        mappedThreshold: mappedThreshold,
         minThreshold: minThreshold,
         maxThreshold: maxThreshold,
         threshold: threshold

--- a/site_store.js
+++ b/site_store.js
@@ -8,7 +8,11 @@ function ssGetModelVersion() {
 }
 
 function ssAddRequestRecord(record) {
-    if (!record || record.linearScore === null || record.linearScore === undefined) {
+    if (!record || record.rocScore === null || record.rocScore === undefined) {
+        return;
+    }
+    const linearScore = rocEstimateLinearScoreAtThreshold(record.rocScore);
+    if (linearScore === null || linearScore === undefined) {
         return;
     }
     const entry = {
@@ -16,7 +20,7 @@ function ssAddRequestRecord(record) {
         pageHost: record.pageHost,
         contentHost: record.contentHost,
         threshold: record.threshold,
-        linearScore: record.linearScore,
+        linearScore: linearScore,
         modelVersion: record.modelVersion ?? SS_MODEL_VERSION,
         key: SS_nextKey++
     };

--- a/site_store.js
+++ b/site_store.js
@@ -15,6 +15,15 @@ function ssAddRequestRecord(record) {
     if (linearScore === null || linearScore === undefined) {
         return;
     }
+    console.info('[SS] record_input ' + JSON.stringify({
+        timestamp: record.timestamp ?? Date.now(),
+        pageHost: record.pageHost,
+        contentHost: record.contentHost,
+        threshold: record.threshold,
+        rocScore: record.rocScore,
+        linearScore: linearScore,
+        modelVersion: record.modelVersion ?? SS_MODEL_VERSION
+    }));
     const entry = {
         timestamp: record.timestamp ?? Date.now(),
         pageHost: record.pageHost,
@@ -37,12 +46,21 @@ function ssGetScoresForPageHost(pageHost) {
             scores.push(SS_records[i].linearScore);
         }
     }
+    console.info('[SS] scores_for_host ' + JSON.stringify({
+        pageHost: pageHost,
+        count: scores.length
+    }));
     return scores;
 }
 
 function ssSuggestAdaptiveThreshold(pageHost, fallbackThreshold, fallbackStdDev, minThreshold, maxThreshold) {
     const scores = ssGetScoresForPageHost(pageHost);
     if (scores.length < 50) {
+        console.info('[SS] threshold_fallback ' + JSON.stringify({
+            pageHost: pageHost,
+            sampleCount: scores.length,
+            fallbackThreshold: fallbackThreshold
+        }));
         return fallbackThreshold;
     }
 
@@ -65,5 +83,17 @@ function ssSuggestAdaptiveThreshold(pageHost, fallbackThreshold, fallbackStdDev,
 
     let threshold = Math.min(suggested, maxThreshold);
     threshold = Math.max(threshold, minThreshold);
+    console.info('[SS] threshold_calc ' + JSON.stringify({
+        pageHost: pageHost,
+        sampleCount: scores.length,
+        mean: mean,
+        stddev: stddev,
+        scaleFactor: scaleFactor,
+        pushFromMean: pushFromMean,
+        suggested: suggested,
+        minThreshold: minThreshold,
+        maxThreshold: maxThreshold,
+        threshold: threshold
+    }));
     return threshold;
 }

--- a/site_store.js
+++ b/site_store.js
@@ -8,7 +8,7 @@ function ssGetModelVersion() {
 }
 
 function ssAddRequestRecord(record) {
-    if (!record || record.rocScore === null || record.rocScore === undefined) {
+    if (!record || record.linearScore === null || record.linearScore === undefined) {
         return;
     }
     const entry = {
@@ -16,7 +16,7 @@ function ssAddRequestRecord(record) {
         pageHost: record.pageHost,
         contentHost: record.contentHost,
         threshold: record.threshold,
-        rocScore: record.rocScore,
+        linearScore: record.linearScore,
         modelVersion: record.modelVersion ?? SS_MODEL_VERSION,
         key: SS_nextKey++
     };
@@ -30,7 +30,7 @@ function ssGetScoresForPageHost(pageHost) {
     const scores = [];
     for (let i = 0; i < SS_records.length; i++) {
         if (SS_records[i].pageHost === pageHost) {
-            scores.push(SS_records[i].rocScore);
+            scores.push(SS_records[i].linearScore);
         }
     }
     return scores;
@@ -55,8 +55,8 @@ function ssSuggestAdaptiveThreshold(pageHost, fallbackThreshold, fallbackStdDev,
     }
     const stddev = Math.sqrt(varianceSum / Math.max(scores.length - 1, 1));
 
-    const scaleFactor = 2 + 30.0 / Math.pow(scores.length, 1.5);
-    const pushFromMean = Math.max(stddev * scaleFactor, fallbackStdDev * 3);
+    const scaleFactor = 1 + 8.0 / Math.pow(scores.length, 0.75);
+    const pushFromMean = Math.max(stddev * scaleFactor, fallbackStdDev * 2);
     const suggested = mean + pushFromMean;
 
     let threshold = Math.min(suggested, maxThreshold);

--- a/status.js
+++ b/status.js
@@ -10,13 +10,6 @@ wingman_icon_32_img.onload = function() {
 //Note: checks can occur that fail and do not result in either a block or a pass.
 //Therefore, use block+pass as the total count in certain cases
 
-let STATUS_imageCounts = {
-    'pass' : 0,
-    'block' : 0,
-    'tiny' : 0,
-    'error' : 0
-};
-let STATUS_imageCheckCount = 0;
 let STATUS_openImageFilters = { };
 let STATUS_openImageHighWaterCount = 0;
 
@@ -35,21 +28,42 @@ const STATUS_ICON_SIZE = 32;
 let STATUS_iconCanvas = document.createElement('canvas');
 STATUS_iconCanvas.width = STATUS_ICON_SIZE;
 STATUS_iconCanvas.height = STATUS_ICON_SIZE;
-let STATUS_zoneFill = 'white';
-let STATUS_zoneFillOffset = 'white';
-
-let STATUS_lastZoneFill = '';
-let STATUS_lastProgressWidth = 0;
-let STATUS_lastIsVideoInProgress = true;
-let STATUS_lastIsVideoBlockShown = true;
-let STATUS_lastVideoProgressCounter = -1;
+const STATUS_defaultZoneFill = '#CCCCCC';
+const STATUS_defaultZoneFillOffset = '#AAAAAA';
+const STATUS_tabState = new Map();
 
 const STATUS_blockFadeoutColors = [
     'rgba(255,0,0,1.0)',
     'rgba(255,0,0,1.0)'
 ];
 
-function statusRegenerateIcon() {
+function statusGetTabState(tabId) {
+    let key = tabId ?? 'global';
+    let state = STATUS_tabState.get(key);
+    if (!state) {
+        state = {
+            imageCounts: {
+                pass: 0,
+                block: 0,
+                tiny: 0,
+                error: 0
+            },
+            imageCheckCount: 0,
+            zoneFill: STATUS_defaultZoneFill,
+            zoneFillOffset: STATUS_defaultZoneFillOffset,
+            lastZoneFill: '',
+            lastProgressWidth: 0,
+            lastIsVideoInProgress: true,
+            lastIsVideoBlockShown: true,
+            lastVideoProgressCounter: -1
+        };
+        STATUS_tabState.set(key, state);
+    }
+    return state;
+}
+
+function statusRegenerateIcon(tabId) {
+    let state = statusGetTabState(tabId);
     // 1. First, do we need to do anything? Do this analysis to avoid extra icon flickering
     let currentProgressWidth = -1;
     if(STATUS_openImageHighWaterCount > 0) {
@@ -65,26 +79,26 @@ function statusRegenerateIcon() {
 
     // TODO reinstate STATUS_videoProgressCounter == STATUS_lastVideoProgressCounter
     // if video progress is ever directly used
-    if(STATUS_zoneFill == STATUS_lastZoneFill &&
-        currentProgressWidth == STATUS_lastProgressWidth &&
-        isVideoInProgress == STATUS_lastIsVideoInProgress &&
-        isVideoBlockShown == STATUS_lastIsVideoBlockShown) {
+    if(state.zoneFill == state.lastZoneFill &&
+        currentProgressWidth == state.lastProgressWidth &&
+        isVideoInProgress == state.lastIsVideoInProgress &&
+        isVideoBlockShown == state.lastIsVideoBlockShown) {
         return;
     }
 
     // 2. Save current state to last state
-    STATUS_lastZoneFill = STATUS_zoneFill;
-    STATUS_lastProgressWidth = currentProgressWidth;
-    STATUS_lastIsVideoInProgress = isVideoInProgress;
-    STATUS_lastIsVideoBlockShown = isVideoBlockShown;
-    STATUS_lastVideoProgressCounter = STATUS_videoProgressCounter;
+    state.lastZoneFill = state.zoneFill;
+    state.lastProgressWidth = currentProgressWidth;
+    state.lastIsVideoInProgress = isVideoInProgress;
+    state.lastIsVideoBlockShown = isVideoBlockShown;
+    state.lastVideoProgressCounter = STATUS_videoProgressCounter;
 
     // 3. Actually generate and set new icon
     let ctx = STATUS_iconCanvas.getContext('2d');
     ctx.clearRect(0,0,STATUS_ICON_SIZE,STATUS_ICON_SIZE);
 
     // Zone background
-    ctx.fillStyle = STATUS_zoneFill;
+    ctx.fillStyle = state.zoneFill;
     ctx.fillRect(0,0,STATUS_ICON_SIZE,STATUS_ICON_SIZE);
 
     // Icon
@@ -92,12 +106,12 @@ function statusRegenerateIcon() {
 
     // Image progress
     if(currentProgressWidth >= 0) {
-        ctx.fillStyle = STATUS_zoneFillOffset;
+        ctx.fillStyle = state.zoneFillOffset;
         ctx.fillRect(0, 24, currentProgressWidth, 8);
     }
 
     if(isVideoInProgress || isVideoBlockShown) {
-        ctx.fillStyle = isVideoBlockShown ? 'white' : STATUS_zoneFillOffset;
+        ctx.fillStyle = isVideoBlockShown ? 'white' : state.zoneFillOffset;
         ctx.fillRect(24, 24, 8, 8);
 
         ctx.fillStyle = isVideoBlockShown ? STATUS_blockFadeoutColors[stepsSinceLastBlock] : 'black';
@@ -107,7 +121,7 @@ function statusRegenerateIcon() {
     }
 
     let imageData = ctx.getImageData(0,0,STATUS_ICON_SIZE,STATUS_ICON_SIZE);
-    browser.browserAction.setIcon({ imageData: imageData });
+    browser.browserAction.setIcon({ imageData: imageData, tabId: tabId ?? undefined });
 }
 
 
@@ -120,22 +134,25 @@ function statusOnLoaded() {
     browser.browserAction.setTitle({title: "Wingman Jr."});
 }
 
-function statusSetImageZoneTrusted() {
-    STATUS_zoneFill = '#88CC88';
-    STATUS_zoneFillOffset = '#66AA66';
-    statusRegenerateIcon();
+function statusSetImageZoneTrusted(tabId) {
+    let state = statusGetTabState(tabId);
+    state.zoneFill = '#88CC88';
+    state.zoneFillOffset = '#66AA66';
+    statusRegenerateIcon(tabId);
 }
 
-function statusSetImageZoneNeutral() {
-    STATUS_zoneFill = '#CCCCCC';
-    STATUS_zoneFillOffset = '#AAAAAA';
-    statusRegenerateIcon();
+function statusSetImageZoneNeutral(tabId) {
+    let state = statusGetTabState(tabId);
+    state.zoneFill = '#CCCCCC';
+    state.zoneFillOffset = '#AAAAAA';
+    statusRegenerateIcon(tabId);
 }
 
-function statusSetImageZoneUntrusted() {
-    STATUS_zoneFill = '#DD9999';
-    STATUS_zoneFillOffset = '#AA6666';
-    statusRegenerateIcon();
+function statusSetImageZoneUntrusted(tabId) {
+    let state = statusGetTabState(tabId);
+    state.zoneFill = '#DD9999';
+    state.zoneFillOffset = '#AA6666';
+    statusRegenerateIcon(tabId);
 }
 
 function statusGetOpenVideoCount() {
@@ -169,37 +186,42 @@ function statusGetOpenImageCount() {
     return Object.keys(STATUS_openImageFilters).length;
 }
 
-function statusStartImageCheck(requestId) {
+function statusStartImageCheck(requestId, tabId) {
     STATUS_openImageFilters[requestId] = requestId;
     let currentLength = statusGetOpenImageCount();
     if(currentLength > STATUS_openImageHighWaterCount) {
         STATUS_openImageHighWaterCount = currentLength;
     }
+    statusRegenerateIcon(tabId);
 }
 
-function statusCompleteImageCheck(requestId, status) {
+function statusCompleteImageCheck(requestId, status, tabId) {
     delete STATUS_openImageFilters[requestId];
-    STATUS_imageCounts[status]++;
-    STATUS_imageCheckCount++;
+    let state = statusGetTabState(tabId);
+    state.imageCounts[status]++;
+    state.imageCheckCount++;
     let currentLength = statusGetOpenImageCount();
     if(currentLength == 0) {
         STATUS_openImageHighWaterCount = 0;
     }
-    statusUpdateVisuals();
+    statusUpdateVisuals(tabId);
 }
 
-function statusUpdateVisuals() {
-    let totalBlockCount = STATUS_imageCounts['block'] + STATUS_videoCounts['block'];
+function statusUpdateVisuals(tabId) {
+    let state = statusGetTabState(tabId);
+    let totalBlockCount = state.imageCounts['block'] + STATUS_videoCounts['block'];
     if(totalBlockCount > 0) {
         //MDN notes we can only fit "about 4" characters here
         let txt = (totalBlockCount < 1000) ? totalBlockCount+'' : '999+';
-        browser.browserAction.setBadgeText({ "text": txt });
+        browser.browserAction.setBadgeText({ "text": txt, tabId: tabId ?? undefined });
+    } else {
+        browser.browserAction.setBadgeText({ "text": '', tabId: tabId ?? undefined });
     }
     
     let openRequestIds = Object.keys(STATUS_openImageFilters);
-    browser.browserAction.setTitle({ title: 'Blocked '+STATUS_imageCounts['block']+'/'+STATUS_imageCheckCount+' images\r\n'
+    browser.browserAction.setTitle({ title: 'Blocked '+state.imageCounts['block']+'/'+state.imageCheckCount+' images\r\n'
         + '               ' + STATUS_videoCounts['block']+'/'+STATUS_videoCheckCount+' videos\r\n'
-        + openRequestIds.length +' open requests: \r\n'+openRequestIds.join('\r\n') });
+        + openRequestIds.length +' open requests: \r\n'+openRequestIds.join('\r\n'), tabId: tabId ?? undefined });
 
-    statusRegenerateIcon();
+    statusRegenerateIcon(tabId);
 }


### PR DESCRIPTION
### Motivation
- Provide per-site adaptive thresholding and persistent statistics so filtering can adapt to individual site distributions and allow site-scoped user overrides. 
- Surface site-aware visual state in the extension action (icon/badge) per active tab so users see the current zone for the page they are viewing. 
- Capture and propagate ROC scores and opaque metadata from the processor to the background so the stats store can learn from real scans.

### Description
- Add an in-memory media statistics store (`media_stats_store.js`) that records recent ROC scores (model tagged as `SQRXR112`) and exposes `ssSuggestAdaptiveThreshold` to suggest per-site thresholds based on observed scores. 
- Wire processor -> background metadata: `rocScore` and `opaque` fields are produced by the processor and consumed by the background, and `ssAddRequestRecord` is called to record scan results. 
- Implement site management utilities and adaptive threshold selection in `background.js`, including `bkExtractRootDomain`, `bkGetTopmostUrl`, per-site settings map, APIs to set/get per-site zone/automatic mode, and `bkPickThreshold` which defers to the stats store when automatic. 
- Add tab-request tracking and tab-scoped visuals: map requestIds to tabIds, update the popup to target the active tab URL, add tab/window listeners and functions to update per-tab icon/badge, and refactor `status.js` to maintain per-tab visual state and badge text. 
- Update `processor.js` to compute and send `rocScore` and carry opaque information through its request lifecycle, and handle error/stat reports with opaque context. 
- Update `manifest.json` to request the `tabs` permission and include the new `media_stats_store.js` in background scripts.

### Testing
- Performed a smoke check by loading `roc.js` via `node -e "const roc=require('./roc.js');"`, which successfully printed the Trusted/Neutral/Untrusted ROC summaries, confirming ROC table parsing and selection logic. 
- No additional automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc13e150483309814e59af0291700)