### PR TITLE
Fix inprocwebgl fallback to launch explicit webgl tab processor

### DIFF
--- a/background.js
+++ b/background.js
@@ -130,8 +130,10 @@ function bkReloadProcessors() {
         if(backend == 'inprocwebgl') {
             console.log(`LIFECYCLE: Probing for inprocwebgl backend`);
             if(!bkTryStartupBackgroundJsProcessor()) {
-                console.log(`LIFECYCLE: Probe for inprocwebgl failed, falling back to webgl`);
-                browser.tabs.create({url:`/processor.html?backend=${backend}&id=${backend}-1`, active: false})
+                const requestedBackend = backend;
+                const effectiveBackend = 'webgl';
+                console.log(`LIFECYCLE: Probe for inprocwebgl failed, launching tab processor (requested=${requestedBackend}, effective=${effectiveBackend})`);
+                browser.tabs.create({url:`/processor.html?backend=${effectiveBackend}&id=${effectiveBackend}-1`, active: false})
                     .then(async tab=>await browser.tabs.hide(tab.id));
             }
         } else {


### PR DESCRIPTION
## Background
Codex found bug #248  while working on feature #247 . Good catch on its part; this is not easy to test so I'm glad it mentioned it.

## Codex Notes
### Motivation
- Ensure that when the `inprocwebgl` probe fails, the code launches a tab processor that explicitly requests a real tab backend instead of propagating `inprocwebgl` in the URL and processor id.
- Avoid ambiguous processor registration ids that could collide or misrepresent the actual runtime backend.
- Make fallback behavior easier to diagnose by logging both the requested and effective backends.

### Description
- Update `bkReloadProcessors()` in `background.js` so the `inprocwebgl` probe-failure path uses a concrete fallback `effectiveBackend = 'webgl'` in the created tab URL and processor id (`webgl-1`).
- Add a lifecycle debug log that reports both `requestedBackend` and `effectiveBackend` when falling back from `inprocwebgl` to `webgl`.
- Preserve the processor registration payload behavior (`backend: PROC_loadedBackend`) in the tab startup code so the runtime-reported backend still reflects TensorFlow.js's actual loaded backend.

### Testing
- Ran `node --check background.js` to validate the modified file and the check completed successfully.
- Verified the new debug log and URL/id substitution are present in `background.js` via a local diff inspection which matched the intended change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d120787c8883309ffd6dc14455e2f6)