### PR TITLE
Make `tabHide` optional and add hidden-tab permission probing with inprocwebgl fallbacks

### DIFF
--- a/background.js
+++ b/background.js
@@ -105,6 +105,45 @@ browser.runtime.onConnect.addListener(bkOnClientConnected);
 
 
 let BK_processorBackendPreference = [];
+let BK_canUseHiddenTab = true;
+let BK_hasHiddenTabPermissionDecision = false;
+
+function bkInitializeHiddenTabPermissionState() {
+    browser.permissions.contains({ permissions: ['tabHide'] })
+        .then(isGranted => {
+            if (isGranted) {
+                BK_canUseHiddenTab = true;
+                BK_hasHiddenTabPermissionDecision = true;
+                return;
+            }
+            browser.storage.local.get('tabhide_prompted_once')
+                .then(result => {
+                    if (result.tabhide_prompted_once === true) {
+                        BK_canUseHiddenTab = false;
+                        BK_hasHiddenTabPermissionDecision = true;
+                        return;
+                    }
+                    browser.storage.local.set({ tabhide_prompted_once: true })
+                        .then(() => browser.permissions.request({ permissions: ['tabHide'] }))
+                        .then(requestResult => {
+                            BK_canUseHiddenTab = requestResult === true;
+                            BK_hasHiddenTabPermissionDecision = true;
+                        })
+                        .catch(() => {
+                            BK_canUseHiddenTab = false;
+                            BK_hasHiddenTabPermissionDecision = true;
+                        });
+                })
+                .catch(() => {
+                    BK_canUseHiddenTab = false;
+                    BK_hasHiddenTabPermissionDecision = true;
+                });
+        })
+        .catch(() => {
+            BK_canUseHiddenTab = false;
+            BK_hasHiddenTabPermissionDecision = true;
+        });
+}
 
 function bkReloadProcessors() {
     WJR_DEBUG && console.log('LIFECYCLE: Cleaning up old processors.');
@@ -127,19 +166,38 @@ function bkReloadProcessors() {
     for(let i=0; i<BK_processorBackendPreference.length; i++) {
         let backend = BK_processorBackendPreference[i];
         WJR_DEBUG && console.log(`LIFECYCLE: Spawning processor with backend ${backend}`);
-        if(backend == 'inprocwebgl') {
-            console.log(`LIFECYCLE: Probing for inprocwebgl backend`);
-            if(!bkTryStartupBackgroundJsProcessor()) {
-                const requestedBackend = backend;
-                const effectiveBackend = 'webgl';
-                console.log(`LIFECYCLE: Probe for inprocwebgl failed, launching tab processor (requested=${requestedBackend}, effective=${effectiveBackend})`);
-                browser.tabs.create({url:`/processor.html?backend=${effectiveBackend}&id=${effectiveBackend}-1`, active: false})
-                    .then(async tab=>await browser.tabs.hide(tab.id));
+        if (backend == 'inprocwebgl') {
+            console.log('LIFECYCLE: Probing for inprocwebgl backend');
+            if (bkTryStartupBackgroundJsProcessor()) {
+                continue;
             }
-        } else {
-            browser.tabs.create({url:`/processor.html?backend=${backend}&id=${backend}-1`, active: false})
-                .then(async tab=>await browser.tabs.hide(tab.id));
+            if (BK_hasHiddenTabPermissionDecision && !BK_canUseHiddenTab) {
+                console.warn('LIFECYCLE: Hidden-tab permission unavailable and inprocwebgl failed.');
+                continue;
+            }
+            console.log('LIFECYCLE: Probe for inprocwebgl failed, attempting hidden-tab webgl.');
+            browser.tabs.create({url:'/processor.html?backend=webgl&id=webgl-1', active: false})
+                .then(async tab => await browser.tabs.hide(tab.id))
+                .catch(() => {
+                    console.warn('LIFECYCLE: Hidden-tab webgl launch failed after inprocwebgl failure.');
+                });
+            continue;
         }
+
+        if (BK_hasHiddenTabPermissionDecision && !BK_canUseHiddenTab) {
+            if (!bkTryStartupBackgroundJsProcessor()) {
+                console.warn(`LIFECYCLE: Could not launch hidden-tab backend ${backend}, and inprocwebgl fallback failed.`);
+            }
+            continue;
+        }
+
+        browser.tabs.create({url:`/processor.html?backend=${backend}&id=${backend}-1`, active: false})
+            .then(async tab => await browser.tabs.hide(tab.id))
+            .catch(() => {
+                if (!bkTryStartupBackgroundJsProcessor()) {
+                    console.warn(`LIFECYCLE: Hidden-tab launch failed for backend ${backend}, and inprocwebgl fallback failed.`);
+                }
+            });
     }
     WJR_DEBUG && console.log('LIFECYCLE: New processors are launching!');
 }
@@ -1319,6 +1377,7 @@ function bkHandleMessage(request, sender, sendResponse) {
     }
 }
 browser.runtime.onMessage.addListener(bkHandleMessage);
+bkInitializeHiddenTabPermissionState();
 browser.storage.local.get('default_zone')
     .then(bkSetDefaultZone)
     .then(() => {

--- a/background.js
+++ b/background.js
@@ -109,39 +109,37 @@ let BK_canUseHiddenTab = true;
 let BK_hasHiddenTabPermissionDecision = false;
 
 function bkInitializeHiddenTabPermissionState() {
+    BK_canUseHiddenTab = false;
+    BK_hasHiddenTabPermissionDecision = true;
     browser.permissions.contains({ permissions: ['tabHide'] })
         .then(isGranted => {
             if (isGranted) {
                 BK_canUseHiddenTab = true;
-                BK_hasHiddenTabPermissionDecision = true;
+                console.log('LIFECYCLE: Hidden tab permisssions were already granted on startup.');
                 return;
             }
             browser.storage.local.get('tabhide_prompted_once')
                 .then(result => {
                     if (result.tabhide_prompted_once === true) {
-                        BK_canUseHiddenTab = false;
-                        BK_hasHiddenTabPermissionDecision = true;
+                        console.log('LIFECYCLE: Hidden tab permisssions were not already granted on startup, but the user has already been prompted on this installation, not prompting again.');
                         return;
                     }
                     browser.storage.local.set({ tabhide_prompted_once: true })
                         .then(() => browser.permissions.request({ permissions: ['tabHide'] }))
                         .then(requestResult => {
                             BK_canUseHiddenTab = requestResult === true;
-                            BK_hasHiddenTabPermissionDecision = true;
+                            console.warn(`LIFECYCLE: Hidden tab permisssions were prompted, and grant result was ${requestResult}`);
                         })
-                        .catch(() => {
-                            BK_canUseHiddenTab = false;
-                            BK_hasHiddenTabPermissionDecision = true;
+                        .catch(promptError => {
+                            console.error('LIFECYCLE: Error while prompting for hidden tab permissions.', promptError);
                         });
                 })
-                .catch(() => {
-                    BK_canUseHiddenTab = false;
-                    BK_hasHiddenTabPermissionDecision = true;
+                .catch(fetchError => {
+                    console.error('LIFECYCLE: Error while processing tabhide_prompted_once:', fetchError);
                 });
         })
-        .catch(() => {
-            BK_canUseHiddenTab = false;
-            BK_hasHiddenTabPermissionDecision = true;
+        .catch(handlingError => {
+            console.log('LIFECYCLE: Error while handling tabHide permissions check: ', handlingError);
         });
 }
 
@@ -169,6 +167,7 @@ function bkReloadProcessors() {
         if (backend == 'inprocwebgl') {
             console.log('LIFECYCLE: Probing for inprocwebgl backend');
             if (bkTryStartupBackgroundJsProcessor()) {
+                console.log('LIFECYCLE inprocwebgl launch success');
                 continue;
             }
             if (BK_hasHiddenTabPermissionDecision && !BK_canUseHiddenTab) {
@@ -178,26 +177,24 @@ function bkReloadProcessors() {
             console.log('LIFECYCLE: Probe for inprocwebgl failed, attempting hidden-tab webgl.');
             browser.tabs.create({url:'/processor.html?backend=webgl&id=webgl-1', active: false})
                 .then(async tab => await browser.tabs.hide(tab.id))
-                .catch(() => {
-                    console.warn('LIFECYCLE: Hidden-tab webgl launch failed after inprocwebgl failure.');
+                .catch(webglCreationError => {
+                    console.warn('LIFECYCLE: Hidden-tab webgl launch issue after inprocwebgl failure.', webglCreationError);
                 });
             continue;
         }
 
         if (BK_hasHiddenTabPermissionDecision && !BK_canUseHiddenTab) {
+            console.warn('LIFECYCLE: User has chosen not to grant hidden-tab, trying inprocwebgl instead');
             if (!bkTryStartupBackgroundJsProcessor()) {
                 console.warn(`LIFECYCLE: Could not launch hidden-tab backend ${backend}, and inprocwebgl fallback failed.`);
+            } else {
+                console.warn('LIFECYCLE: inprocwebgl fallback started after no hidden-tab permission');
             }
             continue;
         }
 
         browser.tabs.create({url:`/processor.html?backend=${backend}&id=${backend}-1`, active: false})
-            .then(async tab => await browser.tabs.hide(tab.id))
-            .catch(() => {
-                if (!bkTryStartupBackgroundJsProcessor()) {
-                    console.warn(`LIFECYCLE: Hidden-tab launch failed for backend ${backend}, and inprocwebgl fallback failed.`);
-                }
-            });
+            .then(async tab => await browser.tabs.hide(tab.id));
     }
     WJR_DEBUG && console.log('LIFECYCLE: New processors are launching!');
 }

--- a/manifest.json
+++ b/manifest.json
@@ -20,9 +20,11 @@
       "menus",
       "proxy",
       "storage",
-      "tabHide",
       "idle",
       "contextMenus"
+    ],
+    "optional_permissions": [
+      "tabHide"
     ],
   
     "background": {


### PR DESCRIPTION
## Developer Notes
See #247 . I believe hidden tabs to still be one of the key user frustrations. Basically I think some users get frustrated by the hidden tabs permission - or in some cases are maybe just confused about it or why it is being requested - and so if the user says "no" it will turn into a graceful fallback rather than an extension-stopping problem.
Now for more testing ...

## Codex Notes

### Motivation

- Avoid always requiring the `tabHide` permission and handle cases where hidden-tab usage is unavailable or denied.
- Probe for the in-process WebGL processor (`inprocwebgl`) first and provide robust fallbacks when it cannot start.
- Prevent repeated permission prompts by recording that the user was already prompted once.

### Description

- Added `BK_canUseHiddenTab` and `BK_hasHiddenTabPermissionDecision` flags and the `bkInitializeHiddenTabPermissionState()` function to probe `browser.permissions.contains`, record a `tabhide_prompted_once` flag in `storage.local`, and request the `tabHide` permission only once when appropriate.
- Updated `bkReloadProcessors()` control flow to: try `inprocwebgl` first, then attempt hidden-tab `webgl` when available, and fall back to `inprocwebgl` or log warnings when hidden-tab launch fails or permission is unavailable.
- Called `bkInitializeHiddenTabPermissionState()` during startup and added defensive `.catch()` handling to ensure consistent permission state on errors.
- Moved `tabHide` out of the required `permissions` list into `optional_permissions` in `manifest.json` to reflect the new runtime-request behavior.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d127e8e8e48330a34935cca3cb9dd7)