### PR TITLE
Hack: Skip downloading known binary file types when Content-Type is not supplied based on extension

### DIFF
--- a/encoders.js
+++ b/encoders.js
@@ -66,6 +66,10 @@ function encDetectCharsetAndSetupDecoderEncoder(details) {
         WJR_DEBUG && console.debug('CHARSET:  '+header.name+': '+header.value);
     }
     if (headerIndex == -1) {
+        if (encHasKnownBinaryExtension(details.url)) {
+            WJR_DEBUG && console.debug('CHARSET: No Content-Type header detected for '+details.url+'but binary extension so skipping.');
+            return;
+        }
       WJR_DEBUG && console.debug('CHARSET: No Content-Type header detected for '+details.url+', adding one by guessing.');
       contentType = encGuessContentType(details);
       headerIndex = details.responseHeaders.length;
@@ -119,6 +123,17 @@ function encDetectCharsetAndSetupDecoderEncoder(details) {
     let encoder = new TextEncoderWithSniffing(decoder);
 
     return [decoder, encoder];
+}
+
+function encHasKnownBinaryExtension(url) {
+    const extension = new URL(url).pathname
+        .toLowerCase()
+        .match(/\.([^.\/]+)$/)?.[1];
+
+    return new Set([
+        '7z', 'bin', 'dll', 'dmg', 'exe', 'img', 'iso',
+        'msi', 'ocx', 'rar', 'tar', 'zip'
+    ]).has(extension);
 }
 
 function encConcatBuffersToUint8Array(buffers) {


### PR DESCRIPTION
This is a pragmatic hack, but one suggested to fix #202 sufficiently well to close it. The true fix would be to do what browsers do and implement the extremely complex routine described in https://github.com/wingman-jr-addon/wingman_jr/issues/202#issuecomment-2408657088 , https://mimesniff.spec.whatwg.org/#mime-type-sniffing-algorithm , and in particular the complexity around step 2: https://mimesniff.spec.whatwg.org/#rules-for-identifying-an-unknown-mime-type

Instead, if there is no Content-Type, fall back to a quick check to allow for certain known binary format extensions to pass through without adding a header.